### PR TITLE
[pose_graph][optimization_problem] Allow new landmarks with existing map

### DIFF
--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -812,7 +812,7 @@ void PoseGraph2D::RunOptimization() {
   // when executing the Solve. Solve is time consuming, so not taking the mutex
   // before Solve to avoid blocking foreground processing.
   optimization_problem_->Solve(data_.constraints, GetTrajectoryStates(),
-                               data_.landmark_nodes);
+                               data_.landmark_nodes, data_.frozen_landmarks);
   absl::MutexLock locker(&mutex_);
 
   const auto& submap_data = optimization_problem_->submap_data();
@@ -931,6 +931,7 @@ void PoseGraph2D::SetLandmarkPose(const std::string& landmark_id,
   AddWorkItem([=]() LOCKS_EXCLUDED(mutex_) {
     absl::MutexLock locker(&mutex_);
     data_.landmark_nodes[landmark_id].global_landmark_pose = global_pose;
+    data_.frozen_landmarks.insert(landmark_id);
     return WorkItem::Result::kDoNotRunOptimization;
   });
 }

--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -828,7 +828,7 @@ void PoseGraph3D::RunOptimization() {
   // Solve. Solve is time consuming, so not taking the mutex before Solve to
   // avoid blocking foreground processing.
   optimization_problem_->Solve(data_.constraints, GetTrajectoryStates(),
-                               data_.landmark_nodes);
+                               data_.landmark_nodes, data_.frozen_landmarks);
   absl::MutexLock locker(&mutex_);
 
   const auto& submap_data = optimization_problem_->submap_data();
@@ -948,6 +948,7 @@ void PoseGraph3D::SetLandmarkPose(const std::string& landmark_id,
   AddWorkItem([=]() LOCKS_EXCLUDED(mutex_) {
     absl::MutexLock locker(&mutex_);
     data_.landmark_nodes[landmark_id].global_landmark_pose = global_pose;
+    data_.frozen_landmarks.insert(landmark_id);
     return WorkItem::Result::kDoNotRunOptimization;
   });
 }

--- a/cartographer/mapping/internal/optimization/optimization_problem_2d.h
+++ b/cartographer/mapping/internal/optimization/optimization_problem_2d.h
@@ -81,7 +81,8 @@ class OptimizationProblem2D
       const std::vector<Constraint>& constraints,
       const std::map<int, PoseGraphInterface::TrajectoryState>&
           trajectories_state,
-      const std::map<std::string, LandmarkNode>& landmark_nodes) override;
+      const std::map<std::string, LandmarkNode>& landmark_nodes,
+      const std::set<std::string>& frozen_landmarks) override;
 
   const MapById<NodeId, NodeSpec2D>& node_data() const override {
     return node_data_;

--- a/cartographer/mapping/internal/optimization/optimization_problem_2d.h
+++ b/cartographer/mapping/internal/optimization/optimization_problem_2d.h
@@ -77,12 +77,11 @@ class OptimizationProblem2D
   void TrimSubmap(const SubmapId& submap_id) override;
   void SetMaxNumIterations(int32 max_num_iterations) override;
 
-  void Solve(
-      const std::vector<Constraint>& constraints,
-      const std::map<int, PoseGraphInterface::TrajectoryState>&
-          trajectories_state,
-      const std::map<std::string, LandmarkNode>& landmark_nodes,
-      const std::set<std::string>& frozen_landmarks) override;
+  void Solve(const std::vector<Constraint>& constraints,
+             const std::map<int, PoseGraphInterface::TrajectoryState>&
+                 trajectories_state,
+             const std::map<std::string, LandmarkNode>& landmark_nodes,
+             const std::set<std::string>& frozen_landmarks) override;
 
   const MapById<NodeId, NodeSpec2D>& node_data() const override {
     return node_data_;

--- a/cartographer/mapping/internal/optimization/optimization_problem_3d.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_3d.cc
@@ -123,16 +123,13 @@ transform::Rigid3d GetInitialLandmarkPose(
 
 void AddLandmarkCostFunctions(
     const std::map<std::string, LandmarkNode>& landmark_nodes,
-    bool freeze_landmarks, const MapById<NodeId, NodeSpec3D>& node_data,
+    const std::set<std::string>& frozen_landmarks,
+    const MapById<NodeId, NodeSpec3D>& node_data,
     MapById<NodeId, CeresPose>* C_nodes,
     std::map<std::string, CeresPose>* C_landmarks, ceres::Problem* problem,
     double huber_scale) {
   for (const auto& landmark_node : landmark_nodes) {
     // Do not use landmarks that were not optimized for localization.
-    if (!landmark_node.second.global_landmark_pose.has_value() &&
-        freeze_landmarks) {
-      continue;
-    }
     for (const auto& observation : landmark_node.second.landmark_observations) {
       const std::string& landmark_id = landmark_node.first;
       const auto& begin_of_trajectory =
@@ -167,7 +164,8 @@ void AddLandmarkCostFunctions(
             CeresPose(starting_point, nullptr /* translation_parametrization */,
                       absl::make_unique<ceres::QuaternionParameterization>(),
                       problem));
-        if (freeze_landmarks) {
+        // Set landmark constant if it is frozen
+        if (frozen_landmarks.count(landmark_node.first) != 0) {
           problem->SetParameterBlockConstant(
               C_landmarks->at(landmark_id).translation());
           problem->SetParameterBlockConstant(
@@ -261,7 +259,8 @@ void OptimizationProblem3D::Solve(
     const std::vector<Constraint>& constraints,
     const std::map<int, PoseGraphInterface::TrajectoryState>&
         trajectories_state,
-    const std::map<std::string, LandmarkNode>& landmark_nodes) {
+    const std::map<std::string, LandmarkNode>& landmark_nodes,
+    const std::set<std::string>& frozen_landmarks) {
   if (node_data_.empty()) {
     // Nothing to optimize.
     return;
@@ -291,7 +290,6 @@ void OptimizationProblem3D::Solve(
   MapById<NodeId, CeresPose> C_nodes;
   std::map<std::string, CeresPose> C_landmarks;
   bool first_submap = true;
-  bool freeze_landmarks = !frozen_trajectories.empty();
   for (const auto& submap_id_data : submap_data_) {
     const bool frozen =
         frozen_trajectories.count(submap_id_data.id.trajectory_id) != 0;
@@ -351,7 +349,7 @@ void OptimizationProblem3D::Solve(
         C_nodes.at(constraint.node_id).translation());
   }
   // Add cost functions for landmarks.
-  AddLandmarkCostFunctions(landmark_nodes, freeze_landmarks, node_data_,
+  AddLandmarkCostFunctions(landmark_nodes, frozen_landmarks, node_data_,
                            &C_nodes, &C_landmarks, &problem,
                            options_.huber_scale());
   // Add constraints based on IMU observations of angular velocities and

--- a/cartographer/mapping/internal/optimization/optimization_problem_3d.h
+++ b/cartographer/mapping/internal/optimization/optimization_problem_3d.h
@@ -77,12 +77,11 @@ class OptimizationProblem3D
   void TrimSubmap(const SubmapId& submap_id) override;
   void SetMaxNumIterations(int32 max_num_iterations) override;
 
-  void Solve(
-      const std::vector<Constraint>& constraints,
-      const std::map<int, PoseGraphInterface::TrajectoryState>&
-          trajectories_state,
-      const std::map<std::string, LandmarkNode>& landmark_nodes,
-      const std::set<std::string>& frozen_landmarks) override;
+  void Solve(const std::vector<Constraint>& constraints,
+             const std::map<int, PoseGraphInterface::TrajectoryState>&
+                 trajectories_state,
+             const std::map<std::string, LandmarkNode>& landmark_nodes,
+             const std::set<std::string>& frozen_landmarks) override;
 
   const MapById<NodeId, NodeSpec3D>& node_data() const override {
     return node_data_;

--- a/cartographer/mapping/internal/optimization/optimization_problem_3d.h
+++ b/cartographer/mapping/internal/optimization/optimization_problem_3d.h
@@ -81,7 +81,8 @@ class OptimizationProblem3D
       const std::vector<Constraint>& constraints,
       const std::map<int, PoseGraphInterface::TrajectoryState>&
           trajectories_state,
-      const std::map<std::string, LandmarkNode>& landmark_nodes) override;
+      const std::map<std::string, LandmarkNode>& landmark_nodes,
+      const std::set<std::string>& frozen_landmarks) override;
 
   const MapById<NodeId, NodeSpec3D>& node_data() const override {
     return node_data_;

--- a/cartographer/mapping/internal/optimization/optimization_problem_3d_test.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_3d_test.cc
@@ -175,7 +175,7 @@ TEST_F(OptimizationProblem3DTest, ReducesNoise) {
   optimization_problem_.AddSubmap(kTrajectoryId, kSubmap2Transform);
   const std::map<int, PoseGraphInterface::TrajectoryState> kTrajectoriesState =
       {{kTrajectoryId, PoseGraphInterface::TrajectoryState::ACTIVE}};
-  optimization_problem_.Solve(constraints, kTrajectoriesState, {});
+  optimization_problem_.Solve(constraints, kTrajectoriesState, {}, {});
 
   double translation_error_after = 0.;
   double rotation_error_after = 0.;

--- a/cartographer/mapping/internal/optimization/optimization_problem_interface.h
+++ b/cartographer/mapping/internal/optimization/optimization_problem_interface.h
@@ -71,7 +71,8 @@ class OptimizationProblemInterface {
       const std::vector<Constraint>& constraints,
       const std::map<int, PoseGraphInterface::TrajectoryState>&
           trajectories_state,
-      const std::map<std::string, LandmarkNode>& landmark_nodes) = 0;
+      const std::map<std::string, LandmarkNode>& landmark_nodes,
+      const std::set<std::string>& frozen_landmarks) = 0;
 
   virtual const MapById<NodeId, NodeDataType>& node_data() const = 0;
   virtual const MapById<SubmapId, SubmapDataType>& submap_data() const = 0;

--- a/cartographer/mapping/internal/optimization/optimization_problem_interface.h
+++ b/cartographer/mapping/internal/optimization/optimization_problem_interface.h
@@ -67,12 +67,11 @@ class OptimizationProblemInterface {
   virtual void SetMaxNumIterations(int32 max_num_iterations) = 0;
 
   // Optimizes the global poses.
-  virtual void Solve(
-      const std::vector<Constraint>& constraints,
-      const std::map<int, PoseGraphInterface::TrajectoryState>&
-          trajectories_state,
-      const std::map<std::string, LandmarkNode>& landmark_nodes,
-      const std::set<std::string>& frozen_landmarks) = 0;
+  virtual void Solve(const std::vector<Constraint>& constraints,
+                     const std::map<int, PoseGraphInterface::TrajectoryState>&
+                         trajectories_state,
+                     const std::map<std::string, LandmarkNode>& landmark_nodes,
+                     const std::set<std::string>& frozen_landmarks) = 0;
 
   virtual const MapById<NodeId, NodeDataType>& node_data() const = 0;
   virtual const MapById<SubmapId, SubmapDataType>& submap_data() const = 0;

--- a/cartographer/mapping/pose_graph_data.h
+++ b/cartographer/mapping/pose_graph_data.h
@@ -74,6 +74,7 @@ struct PoseGraphData {
   // Global landmark poses with all observations.
   std::map<std::string /* landmark ID */, PoseGraphInterface::LandmarkNode>
       landmark_nodes;
+  std::set<std::string /* landmark ID */> frozen_landmarks;
 
   // How our various trajectories are related.
   TrajectoryConnectivityState trajectory_connectivity_state;


### PR DESCRIPTION
In the current implementation, as soon as one trajectory is frozen it is not possible to use new landmarks anymore.
In this PR a suggest a change, that allows introducing new landmarks also in the presence of a frozen trajectory. This is done with the following steps:

- Store set of frozen landmarks
- Landmarks that are loaded from a pbstream, with the flag load_frozen_state=true are inserted into the set of frozen landmarks via setLandmarkPose function
- frozen landmarks are set constant in the optimization problem
- new landmarks can be introduced and will be optimized in the optimization problem
